### PR TITLE
Add CLI for engine performance calculations

### DIFF
--- a/calc.py
+++ b/calc.py
@@ -1,0 +1,70 @@
+"""Engine performance calculation utilities."""
+
+from __future__ import annotations
+
+
+def horsepower(torque: float, rpm: float) -> float:
+    """Calculate horsepower from torque and rpm.
+
+    Args:
+        torque: Engine torque in pound-feet.
+        rpm: Engine speed in revolutions per minute.
+
+    Returns:
+        Horsepower as a float.
+    """
+    return torque * rpm / 5252
+
+
+def torque(horsepower_value: float, rpm: float) -> float:
+    """Calculate torque from horsepower and rpm.
+
+    Args:
+        horsepower_value: Horsepower value.
+        rpm: Engine speed in revolutions per minute.
+
+    Returns:
+        Torque in pound-feet.
+    """
+    return horsepower_value * 5252 / rpm
+
+
+def bmep(torque_value: float, displacement: float) -> float:
+    """Calculate Brake Mean Effective Pressure (BMEP).
+
+    Args:
+        torque_value: Torque in pound-feet.
+        displacement: Engine displacement in cubic inches.
+
+    Returns:
+        BMEP in pounds per square inch (psi).
+    """
+    return (150.8 * torque_value) / displacement
+
+
+def piston_speed(stroke: float, rpm: float) -> float:
+    """Calculate average piston speed.
+
+    Args:
+        stroke: Stroke in inches.
+        rpm: Engine speed in revolutions per minute.
+
+    Returns:
+        Piston speed in feet per minute.
+    """
+    return 2 * stroke * rpm / 12
+
+
+def airflow(displacement: float, rpm: float, ve: float) -> float:
+    """Calculate airflow through the engine.
+
+    Args:
+        displacement: Engine displacement in cubic inches.
+        rpm: Engine speed in revolutions per minute.
+        ve: Volumetric efficiency as a decimal (0-1).
+
+    Returns:
+        Airflow in cubic feet per minute (CFM).
+    """
+    return displacement * rpm * ve / 3456
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,46 @@
+"""Command-line interface for engine performance calculations."""
+
+from calc import horsepower, bmep, piston_speed, airflow
+
+
+def prompt_float(prompt: str) -> float:
+    """Prompt the user for a floating-point number."""
+    while True:
+        try:
+            return float(input(prompt))
+        except ValueError:
+            print("Please enter a valid number.")
+
+
+def main() -> None:
+    """Prompt for inputs and display calculated engine metrics."""
+    displacement = prompt_float("Enter engine displacement (cu in): ")
+    stroke = prompt_float("Enter stroke (in): ")
+    rpm = prompt_float("Enter engine RPM: ")
+    ve_percent = prompt_float("Enter volumetric efficiency (%): ")
+    torque_value = prompt_float("Enter torque (lb-ft): ")
+
+    ve = ve_percent / 100.0
+
+    hp = horsepower(torque_value, rpm)
+    bmep_val = bmep(torque_value, displacement)
+    ps = piston_speed(stroke, rpm)
+    af = airflow(displacement, rpm, ve)
+
+    rows = [
+        ("Horsepower (hp)", hp),
+        ("Torque (lb-ft)", torque_value),
+        ("BMEP (psi)", bmep_val),
+        ("Piston Speed (ft/min)", ps),
+        ("Airflow (CFM)", af),
+    ]
+
+    header = f"{'Metric':<25}{'Value':>15}"
+    print("\n" + header)
+    print("-" * len(header))
+    for label, value in rows:
+        print(f"{label:<25}{value:>15.2f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add calculation utilities for horsepower, BMEP, piston speed, and airflow
- create `main.py` CLI to gather engine inputs and display results in a table

## Testing
- `python -m py_compile main.py calc.py`
- `python main.py <<'EOF'
350
3.48
5000
90
400
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68acce17c02c8323aafd3122d0b3a255